### PR TITLE
fix: swap xy coordinate if custom tms url is used

### DIFF
--- a/src/backend/app/projects/project_crud.py
+++ b/src/backend/app/projects/project_crud.py
@@ -778,6 +778,7 @@ def generate_project_basemap(
             outdir=tiles_dir,
             source=source,
             tms=tms,
+            xy=True if tms else False,
         )
         log.info(f"Basemap created for project ID {project_id}: {outfile}")
 


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [ ] 🍕 Feature
- [X] 🐛 Bug Fix
- [ ] 📝 Documentation
- [ ] 🧑‍💻 Refactor
- [ ] ✅ Test
- [ ] 🤖 Build or CI
- [ ] ❓ Other (please specify)

## Related Issue

MBtiles and PMtiles were failing when custom tms url was used.

## Describe this PR

We need to swap xy co ordinate if custom tms url is used. So, this PR checks whether custom tms url is provided or not. If provided it swaps xy coordinate. 

## Screenshots

Please provide screenshots of the change.

## Alternative Approaches Considered

Did you attempt any other approaches that are not documented in code?

## Review Guide

Notes for the reviewer. How to test this change?

## Checklist before requesting a review

- 📖 Read the FMTM Contributing Guide: <https://github.com/hotosm/fmtm/blob/main/CONTRIBUTING.md>
- 📖 Read the HOT Code of Conduct: <https://docs.hotosm.org/code-of-conduct>
- 👷‍♀️ Create small PRs. In most cases, this will be possible.
- ✅ Provide tests for your changes.
- 📝 Use descriptive commit messages.
- 📗 Update any related documentation and include any relevant screenshots.

## [optional] What gif best describes this PR or how it makes you feel?
