### PR TITLE
Reset osm id sequence for entity creation

### DIFF
--- a/src/backend/migrations/007-reset-starting-osm-ids-seq.sql
+++ b/src/backend/migrations/007-reset-starting-osm-ids-seq.sql
@@ -1,0 +1,20 @@
+DO $$
+DECLARE
+    seq_exists BOOLEAN;
+    seq_start BIGINT;
+BEGIN
+    SELECT EXISTS (
+        SELECT 1 FROM pg_class WHERE relname = 'osm_id_seq'
+    ) INTO seq_exists;
+
+    IF seq_exists THEN
+        SELECT start_value INTO seq_start
+        FROM pg_sequences
+        WHERE schemaname = 'public' AND sequencename = 'osm_id_seq';
+
+        IF seq_start = 30000 THEN
+            ALTER SEQUENCE osm_id_seq RESTART WITH 12000;
+        END IF;
+    END IF;
+END
+$$;


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [ ] 🍕 Feature
- [ ] 🐛 Bug Fix
- [ ] 📝 Documentation
- [x] 🧑‍💻 Refactor
- [ ] ✅ Test
- [ ] 🤖 Build or CI
- [ ] ❓ Other (please specify)

## Related Issue

During new entity creation:
Originally, mappers would manually set their own feature id for buildings.
Later, we generated code to automatically generate feature ids.
Some of the manually generated feature ids and automatically generated feature ids were same.

## Describe this PR

To prevent the issue, the data monitoring team advised to set the starting feature id to 12000.
